### PR TITLE
Fixes variable name

### DIFF
--- a/autoload/root.vim
+++ b/autoload/root.vim
@@ -45,7 +45,7 @@ function! root#FindRoot()
             endif
 
             " If the search hits the end of the list start over
-            if l:liststart == len(g:root#l:patterns)
+            if l:liststart == len(g:root#patterns)
                 let l:liststart = 0
             endif
         endfor


### PR DESCRIPTION
Seems like this was maybe caught up in an overly aggressive find-and-replace in d8114b71deb6242a1b43b80f17040f86f53716c1