### PR TITLE
Bails out on remote or virtual files

### DIFF
--- a/autoload/root.vim
+++ b/autoload/root.vim
@@ -16,6 +16,11 @@ function! root#FindRoot()
         " The plugin doesn't work with autochdir
         set noautochdir
 
+        " The plugin only works with local directories
+        if expand('%:p') =~ '://'
+            return
+        endif
+
         " Start in open file's directory
         lcd %:p:h
         let l:liststart = 0


### PR DESCRIPTION
Some plugins (e.g., [vim-fugitive](https://github.com/tpope/vim-fugitive)) [create virtual files](https://github.com/tpope/vim-fugitive/issues/3) (in the form `fugitive:///Users/foo/bar/baz`) where `lcd %:p:h` doesn't make sense and actually causes the buffer to fail to open properly. This patch implements a guard against obvious examples of this.