### PR TITLE
Support for windows

### DIFF
--- a/autoload/root.vim
+++ b/autoload/root.vim
@@ -37,12 +37,9 @@ function! root#FindRoot()
             let l:match = matchstr(l:fullpath, '\m\C[^\/\\]*$')
             let l:path = matchstr(l:fullpath, '\m\C.*[\/\\]')
 
-            " $HOME + match
-            let l:home = $HOME . '/' . l:pattern
-
-            " If the search hits home try the next item in the list.
+            " If the search hits the root, try the next item in the list.
             " Once a match is found break the loop.
-            if l:fullpath == l:home
+            if l:fullpath == ''
                 let l:liststart = l:liststart + 1
                 lcd %:p:h
             elseif empty(l:match) == 0

--- a/autoload/root.vim
+++ b/autoload/root.vim
@@ -34,8 +34,8 @@ function! root#FindRoot()
             endif
 
             " Split the directory into path/match
-            let l:match = matchstr(l:fullpath, '\m\C[^\/]*$')
-            let l:path = matchstr(l:fullpath, '\m\C.*\/')
+            let l:match = matchstr(l:fullpath, '\m\C[^\/\\]*$')
+            let l:path = matchstr(l:fullpath, '\m\C.*[\/\\]')
 
             " $HOME + match
             let l:home = $HOME . '/' . l:pattern


### PR DESCRIPTION
Make the plugin work when viming on windows. There's an additional commit in this PR that stops the root search when reaching the filesystem root instead of assuming that you always edit under $HOME. It might make sense to make a hybrid solution here, for whatever is hit first ($HOME or the root). I removed it because it had a hard-coded forward slash and I am actually supposed to be working, not working on my tools :-)